### PR TITLE
[bugfix]fix breaking changes for react-native 0.40 edition

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
+++ b/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
@@ -25,6 +25,20 @@ public class ReactNativeAudioPackage implements ReactPackage {
         return modules;
     }
 
+     /**
+     * @return list of JS modules to register with the newly created catalyst instance.
+     * <p/>
+     * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
+     * listed here. Also listing a native module here doesn't imply that the JS implementation of it
+     * will be automatically included in the JS bundle.
+     * @deprecated in react-native v0.47+ edtion
+     */
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+
     /**
      * @param reactContext
      * @return a list of view managers that should be registered with {UIManagerModule}


### PR DESCRIPTION
The breaking change for this file to make this repo compatible with react-native v0.47+  causes the java compilation failed in v0.40 edition